### PR TITLE
Parametrix fix

### DIFF
--- a/petram/solver/mumps_model.py
+++ b/petram/solver/mumps_model.py
@@ -443,12 +443,8 @@ class MUMPSSolver(LinearSolver):
             case_base = MPI.COMM_WORLD.bcast(case_base, root=0)
         if myid == 0:
             s.set_lrhs_nrhs(b.shape[0], b.shape[1])
-            #b = b[:, [1, 0, 3, 2]]
-            #b = b[:, [1, 1, 1, 1]]
             bstack = np.hstack(np.transpose(b))
             bstack = self.make_vector_entries(bstack)
-            np.save("bstack", bstack)
-            np.save("b_data", b)
             s.set_rhs(self.data_array(bstack))
 
         if not self.silent:
@@ -475,9 +471,7 @@ class MUMPSSolver(LinearSolver):
             else:
                 sol = s.get_real_rhs()
 
-            #sol = sol.reshape(len(b), -1)
             sol = np.transpose(sol.reshape(-1, len(b)))
-            np.save("sol", sol)            
             return sol
 
 from petram.mfem_config import use_parallel

--- a/petram/solver/mumps_model.py
+++ b/petram/solver/mumps_model.py
@@ -443,8 +443,12 @@ class MUMPSSolver(LinearSolver):
             case_base = MPI.COMM_WORLD.bcast(case_base, root=0)
         if myid == 0:
             s.set_lrhs_nrhs(b.shape[0], b.shape[1])
+            #b = b[:, [1, 0, 3, 2]]
+            #b = b[:, [1, 1, 1, 1]]
             bstack = np.hstack(np.transpose(b))
             bstack = self.make_vector_entries(bstack)
+            np.save("bstack", bstack)
+            np.save("b_data", b)
             s.set_rhs(self.data_array(bstack))
 
         if not self.silent:
@@ -470,7 +474,10 @@ class MUMPSSolver(LinearSolver):
                 sol = s.get_real_rhs()+1j*s.get_imag_rhs()
             else:
                 sol = s.get_real_rhs()
+
+            #sol = sol.reshape(len(b), -1)
             sol = np.transpose(sol.reshape(-1, len(b)))
+            np.save("sol", sol)            
             return sol
 
 from petram.mfem_config import use_parallel

--- a/petram/solver/parametric.py
+++ b/petram/solver/parametric.py
@@ -188,6 +188,8 @@ class Parametric(SolveStep, NS_mixin):
                                                 phys_range,
                                                 update=True)
                      engine.run_fill_X_block(update=True)
+                     engine.run_assemble_extra_rhs(phys_target, phys_range,
+                                                   update=True)                      
                      engine.run_assemble_b(phys_target, update=True) 
                      engine.run_assemble_blocks(instance.compute_A,
                                                 instance.compute_rhs, 

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ with open(path.join(here, 'README.md')) as f:
 
 setup(
     name='PetraM_Base',
-    version='1.2.2',
+    version='1.2.6',
 
     description='PetraM base package',
     long_description=long_description,


### PR DESCRIPTION
This pull fixes the parametric scanner not to update RHS for Lagrange multiplier.
This allows for run port-scanner (RF) without solving linear system every time.

ToDo:
* engine::run_assemble_extra_rhs was added but at moment this re-fill the matrix too, which is waste.
* separate add_extra_contribution to matrix and rhs