### PR TITLE
Fixed Mesh1D and others

### DIFF
--- a/petram/mesh/mesh_model.py
+++ b/petram/mesh/mesh_model.py
@@ -1,7 +1,7 @@
 import os
 import numpy as np
 import mfem
-from abc import ABC, abstractmethod
+from abc import abstractmethod
 
 PyMFEM_PATH =os.path.dirname(os.path.dirname(mfem.__file__))
 PetraM_PATH =os.getenv("PetraM")

--- a/petram/mesh/mesh_model.py
+++ b/petram/mesh/mesh_model.py
@@ -1,6 +1,7 @@
 import os
 import numpy as np
 import mfem
+from abc import ABC, abstractmethod
 
 PyMFEM_PATH =os.path.dirname(os.path.dirname(mfem.__file__))
 PetraM_PATH =os.getenv("PetraM")
@@ -45,6 +46,19 @@ class Mesh(Model, NS_mixin):
             if isinstance(p, MFEM_MeshRoot): return p           
             p = p.parent
             
+class MeshGenerator(Mesh):
+    isMeshGenerator = True
+    isRefinement = False       
+    def run_serial(self, mesh = None):
+        # By default this will call run. Sub-classes can re-implement this.
+        m = self.run(mesh=mesh)
+        print(m)
+        return m
+     
+    @abstractmethod   
+    def run(self, mesh=None):
+        pass
+     
 class MFEMMesh(Model):  
     can_delete = True
     has_2nd_panel = False
@@ -218,9 +232,7 @@ def format_mesh_characteristic(mesh):
       out.append("kappa_max              : " + str(kappa_max))
    return '\n'.join(out)
 
-class MeshFile(Mesh):
-    isMeshGenerator = True   
-    isRefinement = False   
+class MeshFile(MeshGenerator):
     has_2nd_panel = False        
     def __init__(self, parent = None, **kwargs):
         self.path = kwargs.pop("path", "")
@@ -314,9 +326,6 @@ class MeshFile(Mesh):
                 assert False, "can not find mesh file from relative path: "+path
         return path
 
-    def run_serial(self, mesh = None):
-        # By default this will call run. Sub-classes can re-implement this.
-        return self.run(mesh=mesh)
 
     def run(self, mesh = None):
         path = self.get_real_path()
@@ -334,9 +343,7 @@ class MeshFile(Mesh):
         except:
            return None
         
-class Mesh1D(Mesh):
-    isMeshGenerator = True      
-    isRefinement = False   
+class Mesh1D(MeshGenerator):
     has_2nd_panel = False
     unique_child = True    
 
@@ -428,8 +435,7 @@ class Mesh1D(Mesh):
         except:
            return None
         
-class Mesh2D(Mesh):
-    isMeshGenerator = True      
+class Mesh2D(MeshGenerator):
     isRefinement = False   
     has_2nd_panel = False
     unique_child = True    
@@ -532,9 +538,7 @@ class Mesh2D(Mesh):
         except:
            return None
 
-class Mesh3D(Mesh):
-    isMeshGenerator = True      
-    isRefinement = False   
+class Mesh3D(MeshGenerator):
     has_2nd_panel = False        
     unique_child = True
     

--- a/setup.py
+++ b/setup.py
@@ -16,8 +16,8 @@ with open(path.join(here, 'README.md')) as f:
 
 setup(
     name='PetraM_Base',
-  
-    version='1.3.0',
+
+    version='1.3.1',
 
     description='PetraM base package',
     long_description=long_description,


### PR DESCRIPTION
This pull addresses the issue that run_serial is not defined in mesh generator
other than MFEMMeshFile. 
* added MeshGenerator class, which has run_serial and run (abstract) defined.

Note: 
  If mesh generation is done in sub-class of Mesh, it need to be change to derive it 
from MeshGenerator class 