### PR TITLE
fixed an infinite loop when GetNE < MPI.nproc

### DIFF
--- a/petram/engine.py
+++ b/petram/engine.py
@@ -2867,7 +2867,11 @@ class ParallelEngine(Engine):
                                                    max(smesh.GetBdrAttributeArray())])
                              self.max_attr = np.max([self.max_attr,
                                                 max(smesh.GetAttributeArray())])
-                        self.meshes[idx] = mfem.ParMesh(MPI.COMM_WORLD, smesh)
+                        if smesh.GetNE() < MPI.COMM_WORLD.size:
+                            parts = smesh.GeneratePartitioning(smesh.GetNE()//1000+1, 1)
+                        else:
+                            parts = None
+                        self.meshes[idx] = mfem.ParMesh(MPI.COMM_WORLD, smesh, parts)
                         target = self.meshes[idx]
                     else:
                         if hasattr(o, 'run') and target is not None:

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open(path.join(here, 'README.md')) as f:
 setup(
     name='PetraM_Base',
 
-    version='1.3.7',
+    version='1.3.8',
 
     description='PetraM base package',
     long_description=long_description,


### PR DESCRIPTION
This pull is to avoid an infinite loop encountered with MFEM4.2
This error occurs in a situation when a (partial) mesh size is smaller than the number of
MPI processes. We make a partitioning array outside ParMesh constructor to avoid this
loop