### PR TITLE
address the matrix assmble when coefficient involves H1 vector

### DIFF
--- a/petram/phys/wf/wf_model.py
+++ b/petram/phys/wf/wf_model.py
@@ -298,13 +298,14 @@ class WF(PhysModule):
         return [WF_PeriodicBdr]
 
     def add_variables(self, v, name, solr, soli=None):
-        from petram.helper.variables import add_coordinates
-        from petram.helper.variables import add_scalar
-        from petram.helper.variables import add_components
-        from petram.helper.variables import add_expression
-        from petram.helper.variables import add_surf_normals
-        from petram.helper.variables import add_constant
-        from petram.helper.variables import GFScalarVariable
+        from petram.helper.variables import (add_coordinates,
+                                             add_scalar,
+                                             add_components,
+                                             add_expression,
+                                             add_surf_normals,
+                                             add_constant
+,                                            GFScalarVariable,
+                                             GFVectorVariable)
 
         ind_vars = [x.strip() for x in self.ind_vars.split(',')]
         suffix = self.dep_vars_suffix
@@ -347,4 +348,7 @@ class WF(PhysModule):
                     for k, n in enumerate(names):
                         name = n + suffix
                         v[name] = GFScalarVariable(solr, soli, comp=k+1)
+
+                    allnames = ''.join(names)
+                    v[allnames] = GFVectorVariable(solr, soli)
         return v


### PR DESCRIPTION
This PR fixes the variable when underlining GridFunction is vdim > 1.

* fixed to create  VectorGridfunctionCoefficient 
* WF defines a new variable, which correspoinds to the vector form of solution (in addition to the component-wise variable)

ToDo:
* remove "if True:", once tested.